### PR TITLE
Reduce ceph osd restart occurances

### DIFF
--- a/lib/puppet/provider/ceph_config/ini_setting.rb
+++ b/lib/puppet/provider/ceph_config/ini_setting.rb
@@ -1,0 +1,32 @@
+Puppet::Type.type(:ceph_config).provide(
+  :ini_setting,
+  :parent => Puppet::Type.type(:ini_setting).provider(:ruby)
+) do
+
+  # the setting is always default
+  # this if for backwards compat with the old puppet providers for ceph_config
+  def section
+    resource[:name].split('/', 2)[0]
+  end
+
+  # assumes that the name was the setting
+  # this is to maintain backwards compat with the the older
+  # stuff
+  def setting
+    resource[:name].split('/', 2)[1]
+  end
+
+  def separator
+    '='
+  end
+
+  def self.file_path
+    '/etc/ceph/ceph.conf'
+  end
+
+  # this needs to be removed. This has been replaced with the class method
+  def file_path
+    self.class.file_path
+  end
+
+end

--- a/lib/puppet/type/ceph_config.rb
+++ b/lib/puppet/type/ceph_config.rb
@@ -1,0 +1,55 @@
+Puppet::Type.newtype(:ceph_config) do
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    validate do |value|
+      unless value =~ /\S+\/\S+/
+        fail("Invalid ceph_config #{value}, entries without sections are no longer supported, please add an explicit section (probably DEFAULT) to all ceph_config resources")
+      end
+    end
+  end
+
+  newproperty(:value) do
+    desc 'The value of the setting to be defined.'
+    munge do |value|
+      value = value.to_s.strip
+      value.capitalize! if value =~ /^(true|false)$/i
+      value
+    end
+    newvalues(/^[\S ]*$/)
+
+    def is_to_s( currentvalue )
+      if resource.secret?
+        return '[old secret redacted]'
+      else
+        return currentvalue
+      end
+    end
+
+    def should_to_s( newvalue )
+      if resource.secret?
+        return '[new secret redacted]'
+      else
+        return newvalue
+      end
+    end
+  end
+
+  newparam(:secret, :boolean => true) do
+    desc 'Whether to hide the value from Puppet logs. Defaults to `false`.'
+
+    newvalues(:true, :false)
+
+    defaultto false
+  end
+
+  validate do
+    if self[:ensure] == :present
+      if self[:value].nil?
+        raise Puppet::Error, "Property value must be set for #{self[:name]} when ensure is present"
+      end
+    end
+  end
+
+end

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -8,6 +8,7 @@ define ceph::auth (
   $file_owner   = 'root',
   $keyring_path = '/etc/ceph/keyring',
   $cap          = undef,
+  $ceph_connect_timeout = 5,
 ) {
 
   file { $keyring_path:
@@ -19,10 +20,10 @@ define ceph::auth (
   exec { "exec_add_ceph_auth_${client}":
     command =>  "ceph-authtool ${keyring_path} \
                   --name=client.${client} --add-key \
-                  $(ceph --name mon. --key '${mon_key}' \
+                  $(ceph --connect-timeout $ceph_connect_timeout --name mon. --key '${mon_key}' \
                   auth get-or-create-key client.${client}  ${cap})
                 ",
-    unless  => "ceph -n client.${client} --keyring ${keyring_path} osd stat",
+    unless  => "ceph --connect-timeout $ceph_connect_timeout -n client.${client} --keyring ${keyring_path} osd stat",
     require => File[$keyring_path],
   }
 

--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -53,17 +53,112 @@ class ceph::conf (
     $osd_journal_real = "${osd_data}/journal"
   }
 
-  concat { '/etc/ceph/ceph.conf':
+  Package['ceph'] -> Ceph_config<||>
+  File['/etc/ceph/ceph.conf'] -> Ceph_config<||>
+
+  file { '/etc/ceph/ceph.conf':
     owner   => 'root',
     group   => 0,
     mode    => '0664',
     require => Package['ceph'],
   }
 
-  concat::fragment { 'ceph.conf':
-    target  => '/etc/ceph/ceph.conf',
-    order   => '01',
-    content => template('ceph/ceph.conf.erb'),
+  ceph_config {
+    'global/keyring':                  value => '/etc/ceph/keyring';
+    'global/fsid':                     value => $fsid;
+    'global/pool_default_size':        value => $pool_default_size;
+    'global/osd pool default pg num':  value => $pool_default_pg_num;
+    'global/osd pool default pgp num': value => $pool_default_pgp_num;
+    'mon/mon data':                    value => $mon_data;
+    'osd/filestore flusher':           value => false, tag => 'osd_config';
+    'osd/osd data':                    value => $osd_data, tag => 'osd_config';
+    'osd/osd mkfs type':               value => 'xfs', tag => 'osd_config';
+    'osd/keyring':                     value => "${osd_data}/keyring", tag => 'osd_config';
+    'mds/mds data':                    value => $mds_data;
+    'mds/keyring':                     value => "${mds_data}/keyring";
+
   }
+
+  if $osd_journal_type == 'filesystem' {
+    ceph_config {
+      'osd/osd journal':      value => $osd_journal_real, tag => 'osd_config';
+      'osd/osd journal size': value => $journal_size_mb, tag => 'osd_config';
+    }
+  }
+
+  if $auth_type {
+    ceph_config {
+      'global/auth cluster required': value => $auth_type;
+      'global/auth service required': value => $auth_type;
+      'global/auth client required':  value => $auth_type;
+    }
+  }
+
+  if $signatures_require {
+    ceph_config {
+      'global/cephx require signatures': value => $signatures_require
+    }
+  }
+
+  if $signatures_cluster {
+    ceph_config {
+      'global/cephx cluster require signatures': value => $signatures_cluster
+    }
+  }
+
+  if $signatures_service {
+    ceph_config {
+      'global/cephx service require signatures': value => $signatures_service
+    }
+  }
+
+  if $signatures_sign_msgs {
+    ceph_config {
+      'global/cephx sign messages': value => $signatures_sign_msgs
+    }
+  }
+
+  if $cluster_network {
+    ceph_config {
+      'global/cluster network': value => $cluster_network
+    }
+  }
+
+  if $public_network {
+    ceph_config {
+      'global/public network':  value => $public_network;
+    }
+  }
+
+  if $pool_default_min_size {
+    ceph_config {
+      'global/osd pool default min size': value => $pool_default_min_size
+    }
+  }
+
+  if $pool_default_size {
+    ceph_config {
+      'global/osd pool default size': value => $pool_default_size
+    }
+  }
+
+  if $pool_default_crush_rule {
+    ceph_config {
+      'global/osd pool default crush rule': value => $pool_default_crush_rule
+    }
+  }
+
+  if $mon_timecheck_interval {
+    ceph_config {
+      'global/mon timecheck interval': value => $mon_timecheck_interval
+    }
+  }
+
+  if $mon_init_members {
+    ceph_config {
+      'mon/mon initial members': value => $mon_init_members
+    }
+  }
+
 
 }

--- a/manifests/conf/clients.pp
+++ b/manifests/conf/clients.pp
@@ -4,10 +4,8 @@ define ceph::conf::clients (
   $keyring = "/etc/ceph/keyring.$name",
 ) {
 
-  concat::fragment { "ceph-clients-${name}.conf":
-    target  => '/etc/ceph/ceph.conf',
-    order   => '60',
-    content => template('ceph/ceph.conf-clients.erb'),
+  ceph_config {
+      "client.${name}/keyring":      value => $keyring
   }
 
 }

--- a/manifests/conf/mds.pp
+++ b/manifests/conf/mds.pp
@@ -4,10 +4,7 @@ define ceph::conf::mds (
   $mds_data
 ) {
 
-  @@concat::fragment { "ceph-mds-${name}.conf":
-    target  => '/etc/ceph/ceph.conf',
-    order   => '60',
-    content => template('ceph/ceph.conf-mds.erb'),
+  ceph_config {
+      "mds.${name}/host":      value => $::hostname
   }
-
 }

--- a/manifests/conf/mon.pp
+++ b/manifests/conf/mon.pp
@@ -5,10 +5,8 @@ define ceph::conf::mon (
   $mon_port,
 ) {
 
-  concat::fragment { "ceph-mon-${name}.conf":
-    target  => '/etc/ceph/ceph.conf',
-    order   => '50',
-    content => template('ceph/ceph.conf-mon.erb'),
+  ceph_config {
+    "mon.${name}/host":      value => $::hostname;
+    "mon.${name}/mon addr":  value => "${mon_addr}:${mon_port}";
   }
-
 }

--- a/manifests/conf/mon_config.pp
+++ b/manifests/conf/mon_config.pp
@@ -5,11 +5,8 @@ define ceph::conf::mon_config (
   $mon_port = 6789,
 ) {
 
-  concat::fragment { "ceph-mon-${name}.conf":
-    target  => '/etc/ceph/ceph.conf',
-    order   => '50',
-    content => template('ceph/ceph.conf-mon_config.erb'),
+  ceph_config {
+    "mon.${name}/host":      value => $name;
+    "mon.${name}/mon addr":  value => "${mon_addr}:${mon_port}";
   }
-
-
 }

--- a/manifests/conf/radosgw.pp
+++ b/manifests/conf/radosgw.pp
@@ -12,13 +12,22 @@ define ceph::conf::radosgw (
   $logfile = '/var/log/ceph/radosgw.log',
 ) {
 
-
-  concat::fragment { "ceph-radosgw-${name}.conf":
-    target  => '/etc/ceph/ceph.conf',
-    order   => '70',
-    content => template('ceph/ceph.conf-radosgw.erb'),
-    notify => Service['radosgw'],
+  ceph_config {
+    'client.radosgw.gateway/host':  value => $::hostname;
+    'client.radosgw.gateway/keyring':  value => $keyring;
+    'client.radosgw.gateway/rgw socket path':  value => $socket;
+    'client.radosgw.gateway/log file':  value => $logfile;
+    'client.radosgw.gateway/rgw keystone url':  value => $keystone_url;
+    'client.radosgw.gateway/rgw keystone admin token':  value => $keystone_admin_token;
+    'client.radosgw.gateway/rgw keystone accepted roles':  value => $keystone_accepted_roles;
+    'client.radosgw.gateway/rgw keystone token cache size':  value => $keystone_token_cache_size;
+    'client.radosgw.gateway/rgw keystone revocation interval':  value => $keystone_revocation_interval;
+    'client.radosgw.gateway/rgw s3 auth use keystone':  value => 'true';
   }
 
-
+  if $ceph_radosgw_listen_ssl {
+    ceph_config {
+      'client.radosgw.gateway/nss db path': value => $nss_db_path;
+    }
+  }
 }

--- a/manifests/mon.pp
+++ b/manifests/mon.pp
@@ -56,13 +56,14 @@ define ceph::mon (
     require => Package['ceph'],
   }
 
+  Ceph::Conf::Mon_config<||> -> Exec['ceph-mon-mkfs']
+
   exec { 'ceph-mon-mkfs':
     command => "ceph-mon --mkfs -i ${name} \
 --keyring /var/lib/ceph/tmp/keyring.mon.${name}",
     creates => "${mon_data_real}/keyring",
     require => [
       Package['ceph'],
-      Concat['/etc/ceph/ceph.conf'],
       File[$mon_data_real]
     ],
   }

--- a/manifests/osd/device.pp
+++ b/manifests/osd/device.pp
@@ -156,6 +156,8 @@ size=1024m -n size=64k ${part_prefix}1",
         ],
       }
 
+      Ceph::Conf::Mon_config<||> -> Exec["ceph-osd-mkfs-${osd_id}"]
+
       exec { "ceph-osd-mkfs-${osd_id}":
         command => "ceph-osd -c /etc/ceph/ceph.conf \
 -i ${osd_id} \
@@ -167,7 +169,6 @@ size=1024m -n size=64k ${part_prefix}1",
         unless  => "ceph auth list | egrep '^osd.${osd_id}$'",
         require => [
           Mount[$osd_data],
-          Ceph::Conf::Mon_config<||>
           ],
       }
 

--- a/manifests/radosgw.pp
+++ b/manifests/radosgw.pp
@@ -60,7 +60,7 @@ class ceph::radosgw (
   ##
 
   Ceph::Auth[$radosgw_id] ~> Service['radosgw']
-  Concat['/etc/ceph/ceph.conf'] ~> Service['radosgw']
+  Ceph_config<||> ~> Service['radosgw']
 
   ceph::conf::radosgw { $name:
     keyring                      => $radosgw_keyring_orig,


### PR DESCRIPTION
* Created ceph_config provider
* Changed concat resources with ceph_config - this will keep unmanaged
 configuration entries there until we purge them
* Tag osd specific configurations so that osds restart only if necessary
* Added ceph connection timeout to reduce the wait time (only added to
   ceph::auth right now, can be added other places also)

Note: Once this works, it would make sense to add the same logic to ceph mon
also.