### PR TITLE
pools: Update pools from stackforge module

### DIFF
--- a/manifests/pool.pp
+++ b/manifests/pool.pp
@@ -1,0 +1,119 @@
+# This module is borrowed from git://githib.com/stackforge/puppet-ceph
+#
+# Copyright (C) 2014 Catalyst IT Limited.
+# Copyright (C) 2014 Nine Internet Solutions AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Author: Ricardo Rocha <ricardo@catalyst.net.nz>
+# Author: David Gurtner <aldavud@crimson.ch>
+#
+# Manages operations on the pools in the cluster, such as creating or deleting
+# pools, setting PG/PGP numbers, number of replicas, ...
+#
+# == Define: ceph::pool
+#
+# The name of the pool.
+#
+# === Parameters:
+#
+# [*ensure*] Creates ( present ) or removes ( absent ) a pool.
+#   Optional. Defaults to present.
+#   If set to absent, it will drop the pool and all its data.
+#
+# [*pg_num*] Number of PGs for the pool.
+#   Optional. Default is 64 ( but you probably want to pass a value here ).
+#   Number of Placement Groups (PGs) for a pool, if the pool already
+#   exists this may increase the number of PGs if the current value is lower.
+#   Check http://ceph.com/docs/master/rados/operations/placement-groups/.
+#
+# [*pgp_num*] Same as for pg_num.
+#   Optional. Default is undef.
+#
+# [*size*] Replica level for the pool.
+#   Optional. Default is undef.
+#   Increase or decrease the replica level of a pool.
+#
+define ceph::pool (
+  $ensure = present,
+  $pg_num = 64,
+  $pgp_num = undef,
+  $size = undef,
+) {
+
+  if $ensure == present {
+
+    Ceph_Config<||> -> Exec["create-${name}"]
+    Ceph::Mon<||> -> Exec["create-${name}"]
+    Ceph::Key<||> -> Exec["create-${name}"]
+    exec { "create-${name}":
+      command => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd pool create ${name} ${pg_num}",
+      unless  => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd lspools | grep ' ${name},'",
+    }
+
+    exec { "set-${name}-pg_num":
+      command => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd pool set ${name} pg_num ${pg_num}",
+      unless  => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+test $(ceph osd pool get ${name} pg_num | sed 's/.*:\s*//g') -ge ${pg_num}",
+      require => Exec["create-${name}"],
+    }
+
+    if $pgp_num {
+      exec { "set-${name}-pgp_num":
+        command => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd pool set ${name} pgp_num ${pgp_num}",
+        unless  => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+test $(ceph osd pool get ${name} pgp_num | sed 's/.*:\s*//g') -ge ${pgp_num}",
+        require => Exec["create-${name}"],
+      }
+    }
+
+    if $size {
+      exec { "set-${name}-size":
+        command => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd pool set ${name} size ${size}",
+        unless  => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+test $(ceph osd pool get ${name} size | sed 's/.*:\s*//g') -eq ${size}",
+        require => Exec["create-${name}"],
+      }
+    }
+
+  } elsif $ensure == absent {
+
+    exec { "delete-${name}":
+      command => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd pool delete ${name} ${name} --yes-i-really-really-mean-it",
+      onlyif  => "/bin/true # comment to satisfy puppet syntax requirements
+set -ex
+ceph osd lspools | grep ${name}",
+    } -> Ceph::Mon<| ensure == absent |>
+
+  } else {
+
+    fail("*ensure* must be either present or absent - was '${ensure}'")
+
+  }
+
+}

--- a/spec/defines/ceph_pool_spec.rb
+++ b/spec/defines/ceph_pool_spec.rb
@@ -1,0 +1,108 @@
+# This module is borrowed from git://githib.com/stackforge/puppet-ceph
+#
+# Copyright (C) 2014 Catalyst IT Limited.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Author: Ricardo Rocha <ricardo@catalyst.net.nz>
+#
+
+require 'spec_helper'
+
+describe 'ceph::pool' do
+
+  shared_examples_for 'ceph pool' do
+    describe "create with custom params" do
+
+      let :title do
+        'volumes'
+      end
+
+      let :params do
+        {
+          :ensure  => 'present',
+          :pg_num  => 3,
+          :pgp_num => 4,
+          :size    => 2,
+        }
+      end
+
+      it {
+        is_expected.to contain_exec('create-volumes').with(
+          'command' => "/bin/true # comment to satisfy puppet syntax requirements\nset -ex\nceph osd pool create volumes 3"
+        )
+        is_expected.to contain_exec('set-volumes-pg_num').with(
+          'command' => "/bin/true # comment to satisfy puppet syntax requirements\nset -ex\nceph osd pool set volumes pg_num 3"
+        )
+        is_expected.to contain_exec('set-volumes-pgp_num').with(
+          'command' => "/bin/true # comment to satisfy puppet syntax requirements\nset -ex\nceph osd pool set volumes pgp_num 4"
+        )
+        is_expected.to contain_exec('set-volumes-size').with(
+          'command' => "/bin/true # comment to satisfy puppet syntax requirements\nset -ex\nceph osd pool set volumes size 2"
+        )
+        is_expected.not_to contain_exec('delete-volumes')
+      }
+
+    end
+
+    describe "delete with custom params" do
+
+      let :title do
+        'volumes'
+      end
+
+      let :params do
+        {
+          :ensure => 'absent',
+        }
+      end
+
+      it {
+        is_expected.not_to contain_exec('create-volumes')
+        is_expected.to contain_exec('delete-volumes').with(
+          'command' => "/bin/true # comment to satisfy puppet syntax requirements\nset -ex\nceph osd pool delete volumes volumes --yes-i-really-really-mean-it"
+        )
+      }
+
+    end
+  end
+
+  describe 'Debian Family' do
+
+    let :facts do
+      {
+        :osfamily => 'Debian',
+      }
+    end
+
+    it_configures 'ceph pool'
+  end
+
+  describe 'RedHat Family' do
+
+    let :facts do
+      {
+        :osfamily => 'RedHat',
+      }
+    end
+
+    it_configures 'ceph pool'
+  end
+end
+
+# Local Variables:
+# compile-command: "cd ../.. ;
+#    bundle install ;
+#    bundle exec rake spec
+# "
+# End:


### PR DESCRIPTION
Updating pools module from stackforge/puppet-ceph. This primarily has a
few desirable features, viz. ability to increase pg & pgp size and also
tweaking the replica count of the pool. Also since the namespace is different it allows us to transition to this module from puppet-ceph