### PR TITLE
logfile name fix

### DIFF
--- a/manifests/radosgw.pp
+++ b/manifests/radosgw.pp
@@ -39,7 +39,7 @@ class ceph::radosgw (
   $radosgw_cert_file            = undef,
   $radosgw_key_file             = undef,
   $radosgw_ca_file              = undef,
-  $logfile                      = '/var/log/ceph/radosgw',
+  $logfile                      = '/var/log/ceph/radosgw.log',
   $keyring                      = '/etc/ceph/keyring',
   $radosgw_keyring              = undef,
   $region                       = 'RegionOne',


### PR DESCRIPTION
appending .log to logfile name - to have a standard logfile nomenclature. This will also help in the proper logrotation of radosgw log.