### PR TITLE
mon: add object skew setting

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -43,6 +43,7 @@ class ceph::conf (
   $osd_journal_type	       = 'filesystem',
   $mds_data                = '/var/lib/ceph/mds/ceph-$id',
   $mon_timecheck_interval  = undef,
+  $mon_pg_warn_max_object_skew = undef,
 ) {
 
   include 'ceph::package'
@@ -154,5 +155,10 @@ class ceph::conf (
     }
   }
 
+  if $mon_pg_warn_max_object_skew {
+    ceph_config {
+      'mon/mon pg warn max object skew': value => $mon_pg_warn_max_object_skew
+    }
+  }
 
 }


### PR DESCRIPTION
This is a configuration setting that compares the object in a pool
against the cluster average, the default ratio is 10, which means if a
pool's per pg object count setting compared to the global per pg object
count ratio exceeds the ratio, cluster goes to a warn state. During gate
builds it is safe to tweak this to a higher ratio since rgw will be
loaded a bit due the consul checks

Signed-off-by: Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>